### PR TITLE
Use hidden field for saving address to Scrivito

### DIFF
--- a/app/assets/javascripts/scrivito_google_maps_widget/editing.js.coffee
+++ b/app/assets/javascripts/scrivito_google_maps_widget/editing.js.coffee
@@ -14,7 +14,7 @@ $ ->
         infoWindow = canvas.data('infoWindow')
         marker = canvas.data('marker')
 
-        input = widget.find('input')
+        input = widget.find('input.address-input')
         input.show()
 
         content = canvas.attr('data-location')
@@ -25,10 +25,12 @@ $ ->
         autocomplete = new google.maps.places.Autocomplete(input[0])
         autocomplete.bindTo('bounds', map)
 
+        scrivitoAddressField = widget.find('.scrivito-address-field')
+
         google.maps.event.addListener(autocomplete, 'place_changed', ->
           place = autocomplete.getPlace()
           googleMapsWidget.placeMarker(map, infoWindow, marker, place)
-          input.scrivito('save', place.formatted_address)
+          scrivitoAddressField.scrivito('save', place.formatted_address)
         )
       else
         widgets.html('Google API is not initialized')

--- a/app/assets/stylesheets/scrivito_google_maps_widget/editing.css
+++ b/app/assets/stylesheets/scrivito_google_maps_widget/editing.css
@@ -3,7 +3,8 @@
   border: 1px solid transparent;
   border-radius: 2px 0 0 2px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  margin-top: 16px;
+  margin-top: 10px;
+  min-height: 28px;
   padding: 0 11px 0 13px;
   outline: none;
   text-overflow: ellipsis;

--- a/app/views/google_maps_widget/details.html.erb
+++ b/app/views/google_maps_widget/details.html.erb
@@ -9,7 +9,8 @@
 <%= scrivito_details_for t('scrivito_google_maps_widget.details.address', default: 'Address') do %>
   <div class="google-maps" style="height: 320px">
     <% if scrivito_in_editable_view? %>
-      <%= scrivito_tag(:input, widget, :address, type: 'text') %>
+      <input type="text" class="address-input"></input>
+      <%= scrivito_tag(:div, widget, :address, class: 'scrivito-address-field hidden') %>
     <% end %>
 
     <div class="map" data-zoom="<%= widget.zoom_level %>" data-location="<%= widget.address %>"></div>

--- a/app/views/google_maps_widget/show.html.erb
+++ b/app/views/google_maps_widget/show.html.erb
@@ -1,6 +1,7 @@
 <div class="google-maps" style="height: <%= widget.height %>">
   <% if scrivito_in_editable_view? %>
-    <%= scrivito_tag(:input, widget, :address, type: 'text') %>
+    <input type="text" class="address-input"></input>
+    <%= scrivito_tag(:div, widget, :address, class: 'scrivito-address-field hidden') %>
   <% end %>
 
   <div class="map" data-zoom="<%= widget.zoom_level %>" data-location="<%= widget.address %>"></div>

--- a/lib/scrivito_google_maps_widget/version.rb
+++ b/lib/scrivito_google_maps_widget/version.rb
@@ -1,3 +1,3 @@
 module ScrivitoGoogleMapsWidget
-  VERSION = '0.1.11'
+  VERSION = '0.1.12'
 end


### PR DESCRIPTION
The gem had a problem when used with Scrivito 1.12+. There seems to be a change, that lead to a strange behaviour when rendering the field `address` as `input`: the field was clickable, but you lost focus immediately. And it caused the error: `InvalidValueError: not an instance of HTMLInputElement`. Only way was to hold down the mouse on the field and start typing. I don't know which changes from 1.12 caused this problem to appear, but this PR tries to tackle this with the following approach:

- use a normal input field for handling the autocomplete stuff
- render a hidden field for the scrivito field
- save into this new field when the place changes